### PR TITLE
CheerpJ loader now is called directly from path stored in .env

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,0 @@
-# Environment variables. May be overriden in .env.local file.
-
-PUBLIC_CHEERPJ_ORIGIN="https://cjrtnc.leaningtech.com"

--- a/src/app.html
+++ b/src/app.html
@@ -10,6 +10,9 @@
 			data-domain="javafiddle.leaningtech.com"
 			src="https://plausible.leaningtech.com/js/script.js"
 		></script>
+		<script
+			src="https://cjrtnc.leaningtech.com/4.0/loader.js"
+		></script>
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover" class="overflow-hidden">

--- a/src/lib/CheerpJ.svelte
+++ b/src/lib/CheerpJ.svelte
@@ -1,31 +1,12 @@
 <script lang="ts">
-	import { PUBLIC_CHEERPJ_ORIGIN } from '$env/static/public';
-	import { onMount, createEventDispatcher } from 'svelte';
+	import { createEventDispatcher } from 'svelte';
+	import { browser } from '$app/environment';
 
 	const dispatch = createEventDispatcher<{ ready: undefined }>();
 
 	export let display: HTMLElement;
 
-	let promise: Promise<string | void> = new Promise(() => {});
-	let error = false;
-
-	// Load build of CheerpJ by getting url from LATEST.txt and placing it in script tag
-	onMount(() => {
-		promise = fetch(`${PUBLIC_CHEERPJ_ORIGIN}/LATEST.txt`)
-			.then((res) => res.text())
-			.then((text) => text.trim())
-			.catch((err) => {
-				console.error('Error loading CheerpJ', err);
-				error = true;
-			});
-	});
-
 	async function onLoad() {
-		// CheerpJ funcs should be available now
-		if (!cheerpjInit || !display) {
-			error = true;
-			return;
-		}
 
 		await cheerpjInit({
 			status: 'none',
@@ -34,18 +15,8 @@
 		cheerpjCreateDisplay(-1, -1, display);
 		dispatch('ready');
 	}
+
+	if (browser) {	// so it doesn't run server-side
+		onLoad();
+	}
 </script>
-
-<svelte:head>
-	{#await promise}
-		<!-- CheerpJ is loading -->
-	{:then src}
-		{#if src}
-			<script {src} on:load={onLoad}></script>
-		{/if}
-	{/await}
-</svelte:head>
-
-{#if error}
-	<strong class="p-3">Error loading CheerpJ</strong>
-{/if}


### PR DESCRIPTION
Changed made:

- .env file now has the path of the CheerpJ loader itself
- removed async call for reading the old path to fetch CheerpJ loader, using now dynamic JS to add the <script> (that contains the loader source) tag to <head>