### PR TITLE
Fixed output mode

### DIFF
--- a/src/lib/repl/Output.svelte
+++ b/src/lib/repl/Output.svelte
@@ -3,8 +3,17 @@
 	import Icon from '@iconify/svelte';
 	import { isRunning } from './state';
 	import Loading from '$lib/Loading.svelte';
+	import { browser } from '$app/environment';
 
 	let cjConsole: HTMLPreElement;
+	export let isOutputMode = true;
+
+	function viewInOutputMode() {
+		if (browser) {
+			const url = `/output/${window.location.hash}`;
+			window.open(url, "_blank", "noreferrer");
+		}
+	}
 </script>
 
 <div class="w-full h-full" class:hidden={!$isRunning}>
@@ -37,12 +46,14 @@
 	</section>
 </div>
 
-<div class="absolute top-0 right-0 text-stone-500 text-sm flex items-center select-none">
-	<!-- svelte-ignore a11y-invalid-attribute -->
-	<a href="" target="_blank" rel="noreferrer" class="px-2 py-2" title="Open in new tab">
-		<Icon icon="mi:external-link" class="w-5 h-5" />
-	</a>
-</div>
+{#if isOutputMode}
+	<div class="absolute top-1/2 right-0 text-stone-500 text-sm flex items-center select-none">
+		<!-- svelte-ignore a11y-invalid-attribute -->
+		<button class="px-2 py-2" title="Open in new tab" on:click={viewInOutputMode}>
+			<Icon icon="mi:external-link" class="w-5 h-5" />
+		</button>
+	</div>
+{/if}
 
 <style>
 	:global(#cheerpjDisplay) {

--- a/src/routes/(app)/output/+page.svelte
+++ b/src/routes/(app)/output/+page.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
 	import Output from '$lib/repl/Output.svelte';
+	import { effectiveTheme } from '$lib/settings/store';
 </script>
 
-<Output />
+<div class="w-screen h-screen bg-white text-black dark:bg-stone-900 dark:text-white" class:dark={$effectiveTheme === 'dark'}>
+	<Output isOutputMode={false} />
+</div>


### PR DESCRIPTION
In output mode CheerpJ's results (console and/or display) were shown in a simple new window, the fix was necessary since javafiddle was still relying on the old iframe that contained CheerpJ's elements, that was removed in the last updates, and therefore wasn't working properly anymore.