### PR TITLE
Fix shared url

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -11,7 +11,7 @@
 			src="https://plausible.leaningtech.com/js/script.js"
 		></script>
 		<script
-			src="https://cjrtnc.leaningtech.com/4.1/loader.js"
+			src="https://cjrtnc.leaningtech.com/4.2/loader.js"
 		></script>
 		%sveltekit.head%
 	</head>

--- a/src/lib/compress-fiddle.ts
+++ b/src/lib/compress-fiddle.ts
@@ -38,3 +38,5 @@ class Main {
 		}
 	]
 };
+
+export const defaultFiddleComp = compress(defaultFiddle);

--- a/src/lib/repl/Menu.svelte
+++ b/src/lib/repl/Menu.svelte
@@ -7,9 +7,8 @@
 	import { blur } from 'svelte/transition';
 	import FavouriteButton from './menu/FavouriteButton.svelte';
 	import { files, fiddleTitle, fiddleUpdated, favouriteIndex, autoRun } from './state';
-	import { defaultFiddle } from '$lib/compress-fiddle';
+	import { defaultFiddle, defaultFiddleComp } from '$lib/compress-fiddle';
 	import { goto } from '$app/navigation';
-	import { page } from '$app/stores'
 
 	const dispatch = createEventDispatcher<{ share: undefined; run: undefined }>();
 
@@ -36,8 +35,7 @@
 		if ($favouriteIndex !== -1) {
 			$favouriteIndex = -1;
 		}
-		// clear URL
-		goto($page.url.pathname);
+		goto(`/#${defaultFiddleComp}`);
 	}
 </script>
 

--- a/src/lib/repl/state.ts
+++ b/src/lib/repl/state.ts
@@ -25,8 +25,6 @@ export const favourites = persist(writable<Fiddle[]>([]), createIndexedDBStorage
 // If loaded from favourites, this is the index of this fiddle in favourites
 export const favouriteIndex = writable<number>(-1);
 
-export const description = writable<string>('JavaFiddle is an online, browser-based Java IDE. Create and share Swing applications for free!');
-
 export const autoRun = persist(writable<boolean>(false), createLocalStorage(), 'autoRun');
 
 export const isRunning = writable<boolean>(false);

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -1,25 +1,26 @@
 <script lang="ts">
 	import '../../app.css';
 	import { effectiveTheme } from '$lib/settings/store';
-	import { files, fiddleTitle, fiddleUpdated, description } from '$lib/repl/state';
-	import { decompress, type Fiddle, defaultFiddle } from '$lib/compress-fiddle.js';
+	import { files, fiddleTitle, fiddleUpdated } from '$lib/repl/state';
+	import { decompress, type Fiddle, defaultFiddle, defaultFiddleComp } from '$lib/compress-fiddle.js';
 	import { onMount } from 'svelte';
+	import { goto } from '$app/navigation';
+
+	let description = 'JavaFiddle is an online, browser-based Java IDE. Create and share Swing applications for free!';
 
 	function setFiddle() {
 		const fragmentURL: string = window.location.hash.slice(1);
 		let fiddle: Fiddle;
-		let newDescription: string;
 		if (!fragmentURL) {
 			fiddle = defaultFiddle;
-			newDescription = 'JavaFiddle is an online, browser-based Java IDE. Create and share Swing applications for free!';
+			goto(`/#${defaultFiddleComp}`);
 		} else {
 			fiddle = decompress(fragmentURL);
-			newDescription = fiddle.files[0].content;
+			description = fiddle.files[0].content;
 		}
 		$files = fiddle.files;
 		$fiddleTitle = fiddle.title;
 		$fiddleUpdated = fiddle.updated;
-		$description = newDescription;
 	}
 
 	onMount(() => {
@@ -37,7 +38,7 @@
 			? `${$fiddleTitle} - JavaFiddle`
 			: 'JavaFiddle - Build and share Java code snippets in your browser'}</title
 	>
-	<meta name="description" content={$description} />
+	<meta name="description" content={description} />
 </svelte:head>
 
 <div class="contents" class:dark={$effectiveTheme === 'dark'}>


### PR DESCRIPTION
Now also the basic fiddle case, which previously was not stored inside the URL, is compressed as a fragment.
Update loader to 4.2.